### PR TITLE
Add validated() and sanitised() compatibility

### DIFF
--- a/src/Casting/CastsWhenValidatedTrait.php
+++ b/src/Casting/CastsWhenValidatedTrait.php
@@ -57,9 +57,11 @@ trait CastsWhenValidatedTrait
     /**
      * Get the validated and casted data from the request.
      *
+     * @param string|null $key
+     * @param mixed|null $default
      * @return array
      */
-    public function sanitised()
+    public function sanitised($key = null, $default = null)
     {
         $this->sanitised = (new Caster($this->casts(), []))
             ->setDateFormat($this->dateFormat)
@@ -67,7 +69,7 @@ trait CastsWhenValidatedTrait
 
         $this->passedSanitisation();
 
-        return $this->sanitised;
+        return data_get($this->sanitised, $key, $default);
     }
 
     /**

--- a/src/Casting/CastsWhenValidatedTrait.php
+++ b/src/Casting/CastsWhenValidatedTrait.php
@@ -57,11 +57,11 @@ trait CastsWhenValidatedTrait
     /**
      * Get the validated and casted data from the request.
      *
-     * @param string|null $key
-     * @param mixed|null $default
-     * @return array
+     * @param array|int|string|null $key
+     * @param mixed $default
+     * @return mixed
      */
-    public function sanitised(string $key = null, mixed $default = null)
+    public function sanitised(array|int|string|null $key = null, mixed $default = null): mixed
     {
         $this->sanitised = (new Caster($this->casts(), []))
             ->setDateFormat($this->dateFormat)

--- a/src/Casting/CastsWhenValidatedTrait.php
+++ b/src/Casting/CastsWhenValidatedTrait.php
@@ -61,7 +61,7 @@ trait CastsWhenValidatedTrait
      * @param mixed|null $default
      * @return array
      */
-    public function sanitised($key = null, $default = null)
+    public function sanitised(string $key = null, mixed $default = null)
     {
         $this->sanitised = (new Caster($this->casts(), []))
             ->setDateFormat($this->dateFormat)


### PR DESCRIPTION
I propose extending the sanitised() method of CastsWhenValidatedTrait with $key for getting a specific part of the request and $default for providing call specific default value. 

These changes make sanitised() fully compatible with native validated().

Have a great day!