### PR TITLE
Should we rerun casts?

### DIFF
--- a/src/Casting/CastsWhenValidatedTrait.php
+++ b/src/Casting/CastsWhenValidatedTrait.php
@@ -64,7 +64,7 @@ trait CastsWhenValidatedTrait
      */
     public function sanitised(array|int|string|null $key = null, mixed $default = null): mixed
     {
-        if(is_null($this->sanitised)) {
+        if (is_null($this->sanitised)) {
             $this->sanitised = (new Caster($this->casts(), []))
                 ->setDateFormat($this->dateFormat)
                 ->cast($this->validated());

--- a/src/Casting/CastsWhenValidatedTrait.php
+++ b/src/Casting/CastsWhenValidatedTrait.php
@@ -11,7 +11,7 @@ trait CastsWhenValidatedTrait
      *
      * @var array
      */
-    protected $sanitised = [];
+    protected $sanitised = null;
 
     /**
      * The default storage format of the model's date columns.
@@ -64,11 +64,13 @@ trait CastsWhenValidatedTrait
      */
     public function sanitised(array|int|string|null $key = null, mixed $default = null): mixed
     {
-        $this->sanitised = (new Caster($this->casts(), []))
-            ->setDateFormat($this->dateFormat)
-            ->cast($this->validated());
+        if(is_null($this->sanitised)) {
+            $this->sanitised = (new Caster($this->casts(), []))
+                ->setDateFormat($this->dateFormat)
+                ->cast($this->validated());
 
-        $this->passedSanitisation();
+            $this->passedSanitisation();
+        }
 
         return data_get($this->sanitised, $key, $default);
     }


### PR DESCRIPTION
Hi!

I noticed the casts, as well as the passedSanitisation() hook, are being rerun for every sanitised() call. 

If a developer wants to retrieve one variable at a time (yes, this problem was partially introduced by me):

```
$firstName = $request->sanitised('first_name');
$lastName = $request->sanitised('last_name');
$email = $request->sanitised('email');
```

all casts are performed 3 times.

My proposal is quite simple. Just consider if it is problematic having nullable `protected $sanitised;`.
Thank you